### PR TITLE
Fix unused modifier and extra Spacer after the last cell

### DIFF
--- a/speld/src/main/java/com/yogeshpaliyal/speld/OtpView.kt
+++ b/speld/src/main/java/com/yogeshpaliyal/speld/OtpView.kt
@@ -92,12 +92,12 @@ fun PinInput(
     )
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center
     ) {
         repeat(length) {
             OtpCell(
-                modifier = modifier
+                modifier = Modifier
                     .size(width = 45.dp, height = 45.dp)
                     .clip(MaterialTheme.shapes.large)
                     .background(

--- a/speld/src/main/java/com/yogeshpaliyal/speld/OtpView.kt
+++ b/speld/src/main/java/com/yogeshpaliyal/speld/OtpView.kt
@@ -61,6 +61,7 @@ fun OtpCell(
 @Composable
 fun PinInput(
     modifier: Modifier = Modifier,
+    cellModifier: Modifier = Modifier,
     length: Int = 5,
     value: String = "",
     disableKeypad: Boolean = false,
@@ -97,7 +98,7 @@ fun PinInput(
     ) {
         repeat(length) {
             OtpCell(
-                modifier = Modifier
+                modifier = cellModifier
                     .size(width = 45.dp, height = 45.dp)
                     .clip(MaterialTheme.shapes.large)
                     .background(

--- a/speld/src/main/java/com/yogeshpaliyal/speld/OtpView.kt
+++ b/speld/src/main/java/com/yogeshpaliyal/speld/OtpView.kt
@@ -112,7 +112,8 @@ fun PinInput(
                 isCursorVisible = value.length == it,
                 obscureText
             )
-            Spacer(modifier = Modifier.size(8.dp))
+            if (it != length - 1)
+                Spacer(modifier = Modifier.size(8.dp))
         }
     }
 }


### PR DESCRIPTION
Hi @yogeshpaliyal,
I have faced these issues and fixed them. Please let me know what you think of it.

**unused modifier:** There is a modifier as an argument in `PinInput` which has not been used in the `Row`. So I added another modifier named `cellModifier` and used the `modifier` for the `Row` and the `cellModifier` for the `OtpCell`. I have faced this modifier issue in the `ConstraintLayout` which was not listening to the linking.

**extra Spacer after the last cell:** An extra Spacer is been generated because of the `repeat`.