### PR TITLE
Change MainActivity's example modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ PinInput(value = text.value, obscureText = null) {
 ```kotlin
 val text = remember { mutableStateOf("") }
 PinInput(
-    modifier = Modifier.border(
+    cellModifier = Modifier.border(
         BorderStroke(2.dp, Color.Red),
         shape = RoundedCornerShape(3.dp)
     ), value = text.value,

--- a/app/src/main/java/com/yogeshpaliyal/speld/MainActivity.kt
+++ b/app/src/main/java/com/yogeshpaliyal/speld/MainActivity.kt
@@ -45,7 +45,7 @@ class MainActivity : ComponentActivity() {
 
                         // Bordered PIN View
                         PinInput(
-                            modifier = Modifier.border(
+                            cellModifier = Modifier.border(
                                 BorderStroke(2.dp, Color.Red),
                                 shape = RoundedCornerShape(3.dp)
                             ), value = text.value,


### PR DESCRIPTION
Changed the `modifier` to `cellModifier` to fit with the new version of `PinInput`.